### PR TITLE
update sci-hub url to working official url

### DIFF
--- a/download.py
+++ b/download.py
@@ -69,7 +69,7 @@ def tor_post(url, data):
 
 # URL
 # url = 'http://scihub22266oqcxt.onion'
-url = 'http://sci-hub.tw'
+url = 'http://sci-hub.ru'
 
 # Query
 if len(sys.argv) < 2:


### PR DESCRIPTION
Alexandra also is not happy about 3rd party mirror, see [here](https://twitter.com/ringo_ring/status/1431376651691114501). The modified url does not since ages. 